### PR TITLE
Modify login URL for new login endpoint

### DIFF
--- a/front/components/LoginForm.tsx
+++ b/front/components/LoginForm.tsx
@@ -36,7 +36,7 @@ class LoginForm extends React.Component<MyProps, MyState>  {
       cache: 'default' as RequestCache,
       credentials: 'include' as RequestCredentials,
     };
-    var response = await fetch("https://martine.rest/api/v1/users/"+event.target[0].value, myInit)
+    var response = await fetch("https://martine.rest/api/v1/users/login", myInit)
 
     if (response.status != 200) {
       this.setState({ snackOpen: true,})


### PR DESCRIPTION
Il y a toujours un problème: si on rate la première authentification dans le form de login, ensuite l'authentification quand on rectifie le mot de passe échoue à tous les coups.